### PR TITLE
export FixedVersion as metric label

### DIFF
--- a/pkg/server/collector/trivy.go
+++ b/pkg/server/collector/trivy.go
@@ -40,7 +40,7 @@ func NewTrivyCollector(
 			Namespace: namespace,
 			Name:      "vulnerabilities",
 			Help:      "Vulnerabilities detected by trivy",
-		}, []string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "FixedVersion"}),
+		}, []string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "fixedVersion"}),
 	}
 }
 

--- a/pkg/server/collector/trivy.go
+++ b/pkg/server/collector/trivy.go
@@ -40,7 +40,7 @@ func NewTrivyCollector(
 			Namespace: namespace,
 			Name:      "vulnerabilities",
 			Help:      "Vulnerabilities detected by trivy",
-		}, []string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity"}),
+		}, []string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "FixedVersion"}),
 	}
 }
 
@@ -112,6 +112,7 @@ func (c *TrivyCollector) Scan(ctx context.Context) error {
 				vulnerability.PkgName,
 				vulnerability.InstalledVersion,
 				vulnerability.Severity,
+				vulnerability.FixedVersion,
 			}
 			c.vulnerabilities.WithLabelValues(labels...).Set(1)
 		}

--- a/pkg/server/collector/trivy_test.go
+++ b/pkg/server/collector/trivy_test.go
@@ -47,7 +47,7 @@ func TestTrivyCollectorDescribe(t *testing.T) {
 			prometheus.NewDesc(
 				"trivy_vulnerabilities",
 				"Vulnerabilities detected by trivy",
-				[]string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity"},
+				[]string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "FixedVersion"},
 				nil,
 			),
 			func(got interface{}) cmp.Option {
@@ -120,10 +120,11 @@ func TestTrivyCollectorCollect(t *testing.T) {
 					Namespace: "trivy",
 					Name:      "vulnerabilities",
 					Help:      "Vulnerabilities detected by trivy",
-				}, []string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity"})
+				}, []string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "FixedVersion"})
 				labels := []string{
 					"fake",
 					"fake",
+					"",
 					"",
 					"",
 					"",

--- a/pkg/server/collector/trivy_test.go
+++ b/pkg/server/collector/trivy_test.go
@@ -47,7 +47,7 @@ func TestTrivyCollectorDescribe(t *testing.T) {
 			prometheus.NewDesc(
 				"trivy_vulnerabilities",
 				"Vulnerabilities detected by trivy",
-				[]string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "FixedVersion"},
+				[]string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "fixedVersion"},
 				nil,
 			),
 			func(got interface{}) cmp.Option {
@@ -120,7 +120,7 @@ func TestTrivyCollectorCollect(t *testing.T) {
 					Namespace: "trivy",
 					Name:      "vulnerabilities",
 					Help:      "Vulnerabilities detected by trivy",
-				}, []string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "FixedVersion"})
+				}, []string{"image", "vulnerabilityId", "pkgName", "installedVersion", "severity", "fixedVersion"})
 				labels := []string{
 					"fake",
 					"fake",


### PR DESCRIPTION
I think it would be nice to also have the FixedVersion exported. This way it can be used in dashboards.
(see e.g. these 2 dashboards [https://grafana.com/grafana/dashboards/12330](https://grafana.com/grafana/dashboards/12330) and [https://grafana.com/grafana/dashboards/12331](https://grafana.com/grafana/dashboards/12331) )